### PR TITLE
Enable scrolling in student dashboard tabs

### DIFF
--- a/client/src/pages/student-dashboard.tsx
+++ b/client/src/pages/student-dashboard.tsx
@@ -13,13 +13,19 @@ import type { Patient, Session } from "@shared/schema";
 
 export default function StudentDashboard() {
   const { user } = useAuth();
-  const [selectedPatientId, setSelectedPatientId] = useState<string | undefined>();
-  const [currentMode, setCurrentMode] = useState<"student" | "instructor">("student");
-  const [notifications, setNotifications] = useState<Array<{
-    id: string;
-    type: "success" | "warning" | "error";
-    message: string;
-  }>>([]);
+  const [selectedPatientId, setSelectedPatientId] = useState<
+    string | undefined
+  >();
+  const [currentMode, setCurrentMode] = useState<"student" | "instructor">(
+    "student"
+  );
+  const [notifications, setNotifications] = useState<
+    Array<{
+      id: string;
+      type: "success" | "warning" | "error";
+      message: string;
+    }>
+  >([]);
 
   // For demo purposes, using a hardcoded session ID
   const sessionId = "session-1";
@@ -49,7 +55,7 @@ export default function StudentDashboard() {
   };
 
   const dismissNotification = (id: string) => {
-    setNotifications(prev => prev.filter(n => n.id !== id));
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
   };
 
   if (!selectedPatient) {
@@ -59,7 +65,9 @@ export default function StudentDashboard() {
           currentMode={currentMode}
           onModeChange={setCurrentMode}
           sessionName={session?.name}
-          timeRemaining={session?.timeRemaining ? `${session.timeRemaining}:00` : undefined}
+          timeRemaining={
+            session?.timeRemaining ? `${session.timeRemaining}:00` : undefined
+          }
         />
         <div className="flex flex-1">
           <PatientList
@@ -68,7 +76,9 @@ export default function StudentDashboard() {
             onPatientSelect={handlePatientSelect}
           />
           <div className="flex-1 flex items-center justify-center bg-bg-light">
-            <p className="text-gray-500">Select a patient to view their records</p>
+            <p className="text-gray-500">
+              Select a patient to view their records
+            </p>
           </div>
         </div>
       </div>
@@ -81,19 +91,21 @@ export default function StudentDashboard() {
         currentMode={currentMode}
         onModeChange={setCurrentMode}
         sessionName={session?.name}
-        timeRemaining={session?.timeRemaining ? `${session.timeRemaining}:00` : undefined}
+        timeRemaining={
+          session?.timeRemaining ? `${session.timeRemaining}:00` : undefined
+        }
       />
-      
+
       <div className="flex flex-1 overflow-hidden">
         <PatientList
           patients={patients}
           selectedPatientId={selectedPatientId}
           onPatientSelect={handlePatientSelect}
         />
-        
-        <main className="flex-1 flex flex-col overflow-hidden">
+
+        <main className="flex-1 flex flex-col overflow-auto">
           <PatientHeader patient={selectedPatient} />
-          
+
           <Tabs defaultValue="overview" className="flex-1 flex flex-col">
             <div className="bg-white border-b border-gray-200">
               <TabsList className="h-auto p-0 bg-transparent">
@@ -113,19 +125,22 @@ export default function StudentDashboard() {
                 </div>
               </TabsList>
             </div>
-            
+
             <TabsContent value="overview" className="flex-1 overflow-auto m-0">
               <PatientOverview patient={selectedPatient} />
             </TabsContent>
-            
-            <TabsContent value="assessment" className="flex-1 overflow-auto m-0">
+
+            <TabsContent
+              value="assessment"
+              className="flex-1 overflow-auto m-0"
+            >
               <div className="bg-bg-light p-6">
                 <div className="max-w-7xl mx-auto">
                   <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
                     <h2 className="text-lg font-semibold text-gray-900 mb-6">
                       Patient Assessment & Orders
                     </h2>
-                    
+
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
                       <SoapNotesForm patientId={selectedPatient.id} />
                       <OrdersForm patientId={selectedPatient.id} />
@@ -137,7 +152,7 @@ export default function StudentDashboard() {
           </Tabs>
         </main>
       </div>
-      
+
       <NotificationToast
         notifications={notifications}
         onDismiss={dismissNotification}


### PR DESCRIPTION
## Problem
Students couldn't scroll down in any tab of the dashboard.
Related issue: #1 

## Root Cause
The main container had `overflow-hidden` CSS property, which cuts off content instead of allowing scrolling.

**Location:** `client/src/pages/student-dashboard.tsx` line 106

## Solution
Changed CSS from `overflow-hidden` to `overflow-auto`.