### PR TITLE
feat: add default base URL handling

### DIFF
--- a/src/lib/api-client-v2.ts
+++ b/src/lib/api-client-v2.ts
@@ -1,5 +1,14 @@
+const getDefaultBaseUrl = (): string => {
+	// If running in browser, use the current origin
+	if (typeof window !== "undefined" && window.location) {
+		return window.location.origin;
+	}
+	// Fallback for non-browser environments (e.g., SSR, tests)
+	return "http://localhost:8000";
+};
+
 const API_BASE_URL =
-	import.meta.env.VITE_API_BASE_URL || "http://dmrserver:8000";
+	import.meta.env.VITE_API_BASE_URL || getDefaultBaseUrl();
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 


### PR DESCRIPTION
This pull request improves how the API base URL is determined in `src/lib/api-client-v2.ts`, making the client more robust across different environments. Instead of relying solely on environment variables, it now dynamically selects the base URL based on whether it's running in a browser or a server environment.

Environment detection and configuration:

* Added a `getDefaultBaseUrl` function that returns the current browser origin if available, or falls back to `http://localhost:8000` for non-browser environments.
* Updated the `API_BASE_URL` assignment to use the new `getDefaultBaseUrl` function when the environment variable is not set, improving compatibility for SSR and local development.