### PR TITLE
feat: restrict patient management modals for student users

### DIFF
--- a/src/components/patients/create-patient-modal.tsx
+++ b/src/components/patients/create-patient-modal.tsx
@@ -8,6 +8,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiClientV2 } from "@/lib/queryClient";
 import { getErrorMessage } from "@/lib/error-utils";
 import { GENDER_OPTIONS, getGenderLabel } from "@/lib/constants";
+import { useAuth } from "@/hooks/use-auth";
 
 interface CreatePatientModalProps {
   isOpen: boolean;
@@ -20,6 +21,9 @@ export default function CreatePatientModal({
   onClose,
   onPatientCreated,
 }: CreatePatientModalProps) {
+  const { user } = useAuth();
+  const isStudent = user?.role === "student";
+
   const [formData, setFormData] = useState({
     first_name: "",
     last_name: "",
@@ -68,6 +72,9 @@ export default function CreatePatientModal({
   const handleChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
   };
+
+  // If a student somehow mounts this modal, don't render it.
+  if (isStudent) return null;
 
   if (!isOpen) return null;
 

--- a/src/components/patients/edit-patient-modal.tsx
+++ b/src/components/patients/edit-patient-modal.tsx
@@ -9,6 +9,7 @@ import { apiClientV2 } from "@/lib/queryClient";
 import { getErrorMessage } from "@/lib/error-utils";
 import type { Patient, PatientUpdate } from "@/lib/api-client-v2";
 import { GENDER_OPTIONS, getGenderLabel } from "@/lib/constants";
+import { useAuth } from "@/hooks/use-auth";
 
 interface EditPatientModalProps {
   isOpen: boolean;
@@ -23,6 +24,8 @@ export default function EditPatientModal({
   patient,
   onPatientUpdated,
 }: EditPatientModalProps) {
+  const { user } = useAuth();
+  const isStudent = user?.role === "student";
   const [formData, setFormData] = useState<PatientUpdate>({
     first_name: "",
     last_name: "",
@@ -89,6 +92,9 @@ export default function EditPatientModal({
   const handleChange = (field: keyof PatientUpdate, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
   };
+
+  // If a student somehow mounts this modal, don't render it.
+  if (isStudent) return null;
 
   if (!isOpen) return null;
 

--- a/src/components/patients/patient-header.tsx
+++ b/src/components/patients/patient-header.tsx
@@ -5,6 +5,7 @@ import type { Patient } from "@/lib/api-client-v2";
 import EditPatientModal from "./edit-patient-modal";
 import { getGenderLabel } from "@/lib/constants";
 import { formatDate } from "@/lib/utils";
+import { useAuth } from "@/hooks/use-auth";
 
 interface PatientHeaderProps {
   patient: Patient;
@@ -13,6 +14,8 @@ interface PatientHeaderProps {
 
 export default function PatientHeader({ patient, onPatientUpdated }: PatientHeaderProps) {
   const [isEditing, setIsEditing] = useState(false);
+  const { user } = useAuth();
+  const isStudent = user?.role === "student";
 
   const calculateAge = (dateOfBirth: string) => {
     const today = new Date();
@@ -42,15 +45,17 @@ export default function PatientHeader({ patient, onPatientUpdated }: PatientHead
                 Patient ID: {patient.id}
               </span>
 
-              <Button
-                onClick={() => setIsEditing(true)}
-                variant="outline"
-                size="sm"
-                className="flex items-center space-x-2"
-              >
-                <Edit className="h-4 w-4" />
-                <span>Edit</span>
-              </Button>
+              {!isStudent && (
+                <Button
+                  onClick={() => setIsEditing(true)}
+                  variant="outline"
+                  size="sm"
+                  className="flex items-center space-x-2"
+                >
+                  <Edit className="h-4 w-4" />
+                  <span>Edit</span>
+                </Button>
+              )}
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
@@ -77,12 +82,15 @@ export default function PatientHeader({ patient, onPatientUpdated }: PatientHead
       </div>
 
       {/* Edit Patient Modal */}
-      <EditPatientModal
-        isOpen={isEditing}
-        onClose={() => setIsEditing(false)}
-        patient={patient}
-        onPatientUpdated={handlePatientUpdated}
-      />
+      {/* Only render edit modal for non-students */}
+      {!isStudent && (
+        <EditPatientModal
+          isOpen={isEditing}
+          onClose={() => setIsEditing(false)}
+          patient={patient}
+          onPatientUpdated={handlePatientUpdated}
+        />
+      )}
     </>
   );
 }

--- a/src/components/patients/patient-list.tsx
+++ b/src/components/patients/patient-list.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import type { Patient } from "@/lib/api-client-v2";
 import CreatePatientModal from "./create-patient-modal";
 import { getGenderLabel } from "@/lib/constants";
+import { useAuth } from "@/hooks/use-auth";
 
 interface PatientListProps {
   patients: Patient[];
@@ -25,6 +26,8 @@ export default function PatientList({
   showCreateButton = true, // Default to showing create button
 }: PatientListProps) {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const { user } = useAuth();
+  const isStudent = user?.role === "student";
 
   const getStatusColor = (status?: string) => {
     switch (status?.toLowerCase()) {
@@ -90,16 +93,17 @@ export default function PatientList({
             <>
               <div className="flex justify-between items-center mb-2">
                 <h2 className="text-lg font-semibold text-gray-900">Patient List</h2>
-                {showCreateButton && ( // ONLY show if showCreateButton is true
-                  <Button
-                    onClick={() => setIsCreateModalOpen(true)}
-                    size="sm"
-                    className="bg-hospital-blue hover:bg-hospital-blue/90"
-                  >
-                    <Plus className="h-4 w-4 mr-1" />
-                    Add Patient
-                  </Button>
-                )}
+                {showCreateButton &&
+                  !isStudent && ( // ONLY show if showCreateButton is true AND not a student
+                    <Button
+                      onClick={() => setIsCreateModalOpen(true)}
+                      size="sm"
+                      className="bg-hospital-blue hover:bg-hospital-blue/90"
+                    >
+                      <Plus className="h-4 w-4 mr-1" />
+                      Add Patient
+                    </Button>
+                  )}
               </div>
               <p className="text-sm text-gray-500">Select a patient to view records</p>
             </>
@@ -165,11 +169,14 @@ export default function PatientList({
       </div>
 
       {/* Create Patient Modal */}
-      <CreatePatientModal
-        isOpen={isCreateModalOpen}
-        onClose={() => setIsCreateModalOpen(false)}
-        onPatientCreated={handlePatientCreated}
-      />
+      {/* Only render create modal for non-students */}
+      {!isStudent && (
+        <CreatePatientModal
+          isOpen={isCreateModalOpen}
+          onClose={() => setIsCreateModalOpen(false)}
+          onPatientCreated={handlePatientCreated}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
This pull request introduces access control updates across the patient management components to restrict patient creation and editing features for users with the "student" role. The changes ensure that students cannot see or interact with UI elements or modals related to creating or editing patients, improving both security and user experience.

**Access control for patient creation and editing:**

* Added a check for the current user's role using the `useAuth` hook in `create-patient-modal.tsx`, `edit-patient-modal.tsx`, `patient-header.tsx`, and `patient-list.tsx`, and introduced an `isStudent` variable to conditionally hide features for students. [[1]](diffhunk://#diff-9429d77e917e1f5f528a9cffb2612259ac835df9108b11a9d79270f7fefe94faR11) [[2]](diffhunk://#diff-77cf31196ada9fc5e7edb45768d1196746105e1fc198d5e7c822552800e2d7c3R12) [[3]](diffhunk://#diff-459e5ca1ddfe6cbccca7df5abe6dde23d04232f98c23fe0aad0a807045d77002R8) [[4]](diffhunk://#diff-71a786c08c4a251879639ec37a3925474f9fa36a1b680eaa796dd47fe8fa5823R7)
* In `create-patient-modal.tsx` and `edit-patient-modal.tsx`, the modal components now return `null` if the user is a student, preventing students from mounting these modals. [[1]](diffhunk://#diff-9429d77e917e1f5f528a9cffb2612259ac835df9108b11a9d79270f7fefe94faR24-R26) [[2]](diffhunk://#diff-9429d77e917e1f5f528a9cffb2612259ac835df9108b11a9d79270f7fefe94faR76-R78) [[3]](diffhunk://#diff-77cf31196ada9fc5e7edb45768d1196746105e1fc198d5e7c822552800e2d7c3R27-R28) [[4]](diffhunk://#diff-77cf31196ada9fc5e7edb45768d1196746105e1fc198d5e7c822552800e2d7c3R96-R98)
* In `patient-header.tsx`, the "Edit" button and the edit modal are only rendered for non-student users, hiding editing functionality from students. [[1]](diffhunk://#diff-459e5ca1ddfe6cbccca7df5abe6dde23d04232f98c23fe0aad0a807045d77002R17-R18) [[2]](diffhunk://#diff-459e5ca1ddfe6cbccca7df5abe6dde23d04232f98c23fe0aad0a807045d77002R48) [[3]](diffhunk://#diff-459e5ca1ddfe6cbccca7df5abe6dde23d04232f98c23fe0aad0a807045d77002R58) [[4]](diffhunk://#diff-459e5ca1ddfe6cbccca7df5abe6dde23d04232f98c23fe0aad0a807045d77002R85-R93)
* In `patient-list.tsx`, the "Create Patient" button and create modal are only shown to non-student users, ensuring students cannot initiate patient creation. [[1]](diffhunk://#diff-71a786c08c4a251879639ec37a3925474f9fa36a1b680eaa796dd47fe8fa5823R29-R30) [[2]](diffhunk://#diff-71a786c08c4a251879639ec37a3925474f9fa36a1b680eaa796dd47fe8fa5823L93-R97) [[3]](diffhunk://#diff-71a786c08c4a251879639ec37a3925474f9fa36a1b680eaa796dd47fe8fa5823R172-R179)