### PR TITLE
feat: add pagination badge to file management and patient overview

### DIFF
--- a/src/components/instructors/patients/file-management.tsx
+++ b/src/components/instructors/patients/file-management.tsx
@@ -266,6 +266,7 @@ export default function FileManagement({ patientId }: FileManagementProps) {
                           >
                             {file.category || "Other"}
                           </Badge>
+                          {file.requires_pagination && <Badge variant="secondary">Paginated</Badge>}
                           <span className="text-xs text-gray-500">Patient #{file.patient}</span>
                         </div>
                       </div>

--- a/src/components/instructors/patients/patient-overview.tsx
+++ b/src/components/instructors/patients/patient-overview.tsx
@@ -172,6 +172,7 @@ export default function InstructorPatientOverview({ patient }: InstructorPatient
                     </div>
                     <div className="flex items-center gap-2">
                       <Badge variant="outline">{file.category || "Document"}</Badge>
+                      {file.requires_pagination && <Badge variant="secondary">Paginated</Badge>}
                       <Button variant="ghost" size="sm" onClick={() => setPreviewFile(file)}>
                         <Eye className="h-4 w-4" />
                         Preview


### PR DESCRIPTION
This pull request adds a visual indicator for files that require pagination in both the file management and patient overview components. The most important changes are:

**UI Enhancements:**

* In `src/components/instructors/patients/file-management.tsx`, a "Paginated" badge is now displayed next to files that have the `requires_pagination` property set, making it easier to identify paginated files in the file list.
* In `src/components/instructors/patients/patient-overview.tsx`, the same "Paginated" badge is shown for files with `requires_pagination` in the patient overview, improving consistency and visibility across the application.